### PR TITLE
Improve rendering perfomance by memoize expensive measureText calls

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,7 +29,7 @@ publish {
     userOrg = 'carbs'
     groupId = 'cn.carbswang.android'
     artifactId = 'NumberPickerView'
-    publishVersion = '1.1.1'
+    publishVersion = '1.2.0'
     desc = 'another NumberPicker with more flexible attributes on Android platform'
     website = 'https://github.com/Carbs0126/NumberPickerView'
 }

--- a/library/src/main/java/cn/carbswang/android/numberpickerview/library/NumberPickerView.java
+++ b/library/src/main/java/cn/carbswang/android/numberpickerview/library/NumberPickerView.java
@@ -18,6 +18,9 @@ import android.view.VelocityTracker;
 import android.view.View;
 import android.view.ViewConfiguration;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Created by Carbs.Wang.
  * email : yeah0126@yeah.net
@@ -177,6 +180,8 @@ public class NumberPickerView extends View{
     private HandlerThread mHandlerThread;
     private Handler mHandlerInNewThread;
     private Handler mHandlerInMainThread;
+
+    private Map<String, Integer> textWidthCache = new ConcurrentHashMap<>();
 
     // compatible for NumberPicker
     public interface OnValueChangeListener{
@@ -1326,10 +1331,20 @@ public class NumberPickerView extends View{
     }
 
     private int getTextWidth(CharSequence text, Paint paint){
-        if(!TextUtils.isEmpty(text)){
-            return (int)(paint.measureText(text.toString()) + 0.5f);
+        if(TextUtils.isEmpty(text)){
+           return 0;
         }
-        return 0;
+        String key = text.toString();
+
+        if (textWidthCache.containsKey(key)) {
+            return textWidthCache.get(key);
+        }
+
+        int value = (int)(paint.measureText(text.toString()) + 0.5f);
+        textWidthCache.put(key, value);
+
+        return value;
+
     }
 
     private void updateMaxHeightOfDisplayedValues(){


### PR DESCRIPTION
`measureText` is an expensive call and its result can efficiently be memoized to provide a significant performance improvement.
In the `TimePickerView` example only 76 calls (with a non-empty text) out of 1186 to `getTextWidth` will result in a `paint.measureText` call, which means only the 6%. The result of the other 94% calls will be retrieved from the local cache.